### PR TITLE
operation name when using ConnectServiceAccount functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEs
+.idea
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/rubrikpolaris/util.go
+++ b/rubrikpolaris/util.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+const (
+	operationNamePrefix = "SdkGoLang"
+)
+
 // ExpandTildePath will replace a "~/" prefix with the user home directory.
 // Caveat: only "~/" is supported (~user/path is not).
 func ExpandTildePath(path string) (string, error) {
@@ -20,7 +24,7 @@ func ExpandTildePath(path string) (string, error) {
 	return path, nil
 }
 
-// GetStringFromSlice is a workaround for Go's lack of default func params:
+// GetStringFromSlice is useful to emulate default function params:
 // it returns s[index] if it exists; if it doesn't, it returns defaultVal;
 // if replaceEmpty is true and s[index] is empty, it also returns defaultVal.
 func GetStringFromSlice(s []string, index int, replaceEmpty bool,
@@ -29,4 +33,23 @@ func GetStringFromSlice(s []string, index int, replaceEmpty bool,
 		return s[index]
 	}
 	return defaultVal
+}
+
+// OperationNamePrefix returns a prefix string to be used when sending up
+// operation names to Rubrik. The default is "SdkGoLang".
+// So for instance if sending up the query "RadarEventsPerTimePeriod",
+// the operation name will be "SdkGoLangRadarEventsPerTimePeriod".
+//
+// A less common use case is to specify a *second* prefix: say
+// operationNameSecondPrefix="XYZ", then for the query above, the operation
+// name sent up to Rubrik would be "SdkGoLangXYZRadarEventsPerTimePeriod"
+func OperationNamePrefix(operationNameSecondPrefix ...string) string {
+	if len(operationNameSecondPrefix) == 0 {
+		return operationNamePrefix
+	}
+	op := operationNameSecondPrefix[0]
+	if !strings.HasPrefix(op, operationNamePrefix) {
+		return operationNamePrefix + op
+	}
+	return op
 }


### PR DESCRIPTION
- ConnectServiceAccountFromFile and ConnectServiceAccountFromString now support custom operation names.
- Support for custom Polaris hosts; although uncommon, a service account file can specify a custom arbitrary host name for the Polaris host to connect to, this PR introduces support for that.