### PR TITLE
Fix polaris related gql queries and add all cluster specific endpoint

### DIFF
--- a/staticfile/query/AllPolarisEventPerTimePeriod.graphql
+++ b/staticfile/query/AllPolarisEventPerTimePeriod.graphql
@@ -1,47 +1,47 @@
-query AllPolarisEventPerTimePeriod($timeAgo: DateTime, $after: String) {
-	activitySeriesConnection(
-		filters: {
-			clusterId: ["00000000-0000-0000-0000-000000000000"]
-			startTimeGt: $timeAgo
-			lastUpdatedTimeGt: $timeAgo
-		}
-		first: 20
-		after: $after
-	) {
-		edges {
-			node {
-				id
-				fid
-				activitySeriesId
-				lastUpdated
-				lastActivityType
-				lastActivityStatus
-				objectId
-				objectName
-				objectType
-				severity
-				progress
-				cluster {
-					id
-					name
-				}
-				cluster {
-					id
-					name
-				}
-				activityConnection {
-					nodes {
-						id
-						message
-						time
-					}
-				}
-			}
-		}
-		pageInfo {
-			endCursor
-			hasNextPage
-			hasPreviousPage
-		}
-	}
+query AllPolarisEventPerTimePeriod(
+  $timeAgo: DateTime
+  $clusterId: String
+  $after: String
+) {
+  activitySeriesConnection(
+    filters: { clusterId: [$clusterId], lastUpdatedTimeGt: $timeAgo }
+    first: 20
+    after: $after
+  ) {
+    edges {
+      node {
+        id
+        fid
+        activitySeriesId
+        lastUpdated
+        lastActivityType
+        lastActivityStatus
+        objectId
+        objectName
+        objectType
+        severity
+        progress
+        cluster {
+          id
+          name
+        }
+        cluster {
+          id
+          name
+        }
+        activityConnection {
+          nodes {
+            id
+            message
+            time
+          }
+        }
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
 }

--- a/staticfile/query/RadarEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarEventsPerTimePeriod.graphql
@@ -1,30 +1,32 @@
 query RadarEventsPerTimePeriod($timeAgo: DateTime) {
-	activitySeriesConnection(filters: { lastActivityType: [ANOMALY], startTimeGt: $timeAgo }) {
-		edges {
-			node {
-				id
-				fid
-				activitySeriesId
-				lastUpdated
-				lastActivityType
-				lastActivityStatus
-				objectId
-				objectName
-				objectType
-				severity
-				progress
-				cluster {
-					id
-					name
-				}
-				activityConnection {
-					nodes {
-						id
-						message
-						time
-					}
-				}
-			}
-		}
-	}
+  activitySeriesConnection(
+    filters: { lastActivityType: [ANOMALY], lastUpdatedTimeGt: $timeAgo }
+  ) {
+    edges {
+      node {
+        id
+        fid
+        activitySeriesId
+        lastUpdated
+        lastActivityType
+        lastActivityStatus
+        objectId
+        objectName
+        objectType
+        severity
+        progress
+        cluster {
+          id
+          name
+        }
+        activityConnection {
+          nodes {
+            id
+            message
+            time
+          }
+        }
+      }
+    }
+  }
 }

--- a/staticfile/query/RadarSonarEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarSonarEventsPerTimePeriod.graphql
@@ -1,30 +1,35 @@
 query RadarSonarEventsPerTimePeriod($timeAgo: DateTime) {
-	activitySeriesConnection(filters: { lastActivityType: [ANOMALY, CLASSIFICATION], startTimeGt: $timeAgo }) {
-		edges {
-			node {
-				id
-				fid
-				activitySeriesId
-				lastUpdated
-				lastActivityType
-				lastActivityStatus
-				objectId
-				objectName
-				objectType
-				severity
-				progress
-				cluster {
-					id
-					name
-				}
-				activityConnection {
-					nodes {
-						id
-						message
-						time
-					}
-				}
-			}
-		}
-	}
+  activitySeriesConnection(
+    filters: {
+      lastActivityType: [ANOMALY, CLASSIFICATION]
+      lastUpdatedTimeGt: $timeAgo
+    }
+  ) {
+    edges {
+      node {
+        id
+        fid
+        activitySeriesId
+        lastUpdated
+        lastActivityType
+        lastActivityStatus
+        objectId
+        objectName
+        objectType
+        severity
+        progress
+        cluster {
+          id
+          name
+        }
+        activityConnection {
+          nodes {
+            id
+            message
+            time
+          }
+        }
+      }
+    }
+  }
 }

--- a/staticfile/query/RadarTotalEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarTotalEventsPerTimePeriod.graphql
@@ -1,5 +1,7 @@
 query RadarTotalEventsPerTimePeriod($timeAgo: DateTime) {
-	activitySeriesConnection(filters: { lastActivityType: [ANOMALY], startTimeGt: $timeAgo }) {
-		count
-	}
+  activitySeriesConnection(
+    filters: { lastActivityType: [ANOMALY], startTimeGt: $timeAgo }
+  ) {
+    count
+  }
 }


### PR DESCRIPTION
Start using update date to fetch polaris records as single series will have multiple records and updated date will keep updating over time. If you use start time then you will miss some records in series.

Create another endpoint to fetch events from other clusters based on clients needs where they don't want to enable webhooks features due to security concerns.