### PR TITLE
Make activitySeriesConnection queries efficient

### DIFF
--- a/rubrikpolaris/event.go
+++ b/rubrikpolaris/event.go
@@ -6,6 +6,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const (
+	// successiveEventQueryWaitPeriod is the time period in seconds to wait before
+	// making the activitySeriesConnection query again
+	successiveEventQueryWaitPeriod = 30
+)
+
 func (c *Credentials) GetAllEvents(secondsTimeRange int, timeout ...int) (*AllEvents, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -137,6 +143,9 @@ func (c *Credentials) GetAllRscEventsForCluster(timeAgo string, clusterId string
 			}
 
 			variables["after"] = apiResponsePagination.Data.ActivitySeriesConnection.PageInfo.EndCursor
+
+			// Add some sleep before successive activitySeriesConnection queries to ease load on the database
+			time.Sleep(time.Duration(successiveEventQueryWaitPeriod) * time.Second)
 
 		}
 

--- a/staticfile/query/AllPolarisEventPerTimePeriod.graphql
+++ b/staticfile/query/AllPolarisEventPerTimePeriod.graphql
@@ -5,7 +5,7 @@ query AllPolarisEventPerTimePeriod(
 ) {
   activitySeriesConnection(
     filters: { clusterId: [$clusterId], lastUpdatedTimeGt: $timeAgo }
-    first: 20
+    first: 1000
     after: $after
   ) {
     edges {
@@ -29,7 +29,7 @@ query AllPolarisEventPerTimePeriod(
           id
           name
         }
-        activityConnection {
+        activityConnection (first: 20) {
           nodes {
             id
             message

--- a/staticfile/query/RadarEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarEventsPerTimePeriod.graphql
@@ -1,6 +1,7 @@
 query RadarEventsPerTimePeriod($timeAgo: DateTime) {
   activitySeriesConnection(
     filters: { lastActivityType: [ANOMALY], lastUpdatedTimeGt: $timeAgo }
+    first: 1000
   ) {
     edges {
       node {
@@ -19,7 +20,7 @@ query RadarEventsPerTimePeriod($timeAgo: DateTime) {
           id
           name
         }
-        activityConnection {
+        activityConnection (first: 20) {
           nodes {
             id
             message

--- a/staticfile/query/RadarSonarEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarSonarEventsPerTimePeriod.graphql
@@ -22,7 +22,7 @@ query RadarSonarEventsPerTimePeriod($timeAgo: DateTime) {
           id
           name
         }
-        activityConnection {
+        activityConnection (first: 20) {
           nodes {
             id
             message

--- a/staticfile/query/RadarTotalEventsPerTimePeriod.graphql
+++ b/staticfile/query/RadarTotalEventsPerTimePeriod.graphql
@@ -1,7 +1,0 @@
-query RadarTotalEventsPerTimePeriod($timeAgo: DateTime) {
-  activitySeriesConnection(
-    filters: { lastActivityType: [ANOMALY], startTimeGt: $timeAgo }
-  ) {
-    count
-  }
-}


### PR DESCRIPTION
Add limits to activity and series connection wherever missing.
Remove radar events query which is not used anywhere
Add sleep between consecutive activitySeriesConnection calls